### PR TITLE
894 taxon edit page

### DIFF
--- a/src/api/bulk/bulk.service.ts
+++ b/src/api/bulk/bulk.service.ts
@@ -1,7 +1,7 @@
 import { Prisma} from "@prisma/client";
 import { prisma } from "../../utils/constants";
 import { CritterUpdate } from "../critter/critter.utils";
-import { CollectionUnitUpdateInput } from "../collectionUnit/collectionUnit.utils";
+import { CollectionUnitDeleteSchema, CollectionUnitUpsertType } from "../collectionUnit/collectionUnit.utils";
 import {
   MarkingDeleteSchema,
   MarkingUpdateByIdSchema
@@ -13,6 +13,7 @@ import { apiError } from "../../utils/types";
 import { updateCapture } from "../capture/capture.service";
 import { z } from "zod";
 import { deleteMarking } from "../marking/marking.service";
+import { deleteCollectionUnit } from "../collectionUnit/collectionUnit.service";
 
 interface IBulkCreate {
   critters: Prisma.critterCreateManyInput[];
@@ -25,13 +26,14 @@ interface IBulkCreate {
 
 interface IBulkMutate {
   critters: CritterUpdate[];
-  collections: CollectionUnitUpdateInput[];
+  collections: CollectionUnitUpsertType[];
   markings: z.infer<typeof MarkingUpdateByIdSchema>[];
   locations: Prisma.locationUpdateInput[];
   captures: CaptureUpdate[];
   mortalities: MortalityUpdate[];
   //Deletes
   _deleteMarkings: z.infer<typeof MarkingDeleteSchema>[];
+  _deleteUnits: z.infer<typeof CollectionUnitDeleteSchema>[];
 }
 
 interface IBulkResCount {
@@ -83,6 +85,7 @@ const bulkUpdateData = async (bulkParams: IBulkMutate) => {
     mortalities,
     markings,
     _deleteMarkings,
+    _deleteUnits
   } = bulkParams;
   const counts: Omit<IBulkResCount, "created"> = {
     updated: {},
@@ -100,10 +103,20 @@ const bulkUpdateData = async (bulkParams: IBulkMutate) => {
     for (let i = 0; i < collections.length; i++) {
       const c = collections[i];
       counts.updated.collections = i + 1;
-      await prisma.critter_collection_unit.update({
-        where: { critter_collection_unit_id: c.critter_collection_unit_id },
-        data: c,
-      });
+      if(c.critter_collection_unit_id) {
+        await prisma.critter_collection_unit.update({
+          where: { critter_collection_unit_id: c.critter_collection_unit_id },
+          data: c,
+        });
+      }
+      else if(c.critter_id !== undefined) {
+        await prisma.critter_collection_unit.create({
+          data: { //XOR typing seems to force me to use the connect syntax here 
+            critter: { connect: { critter_id: c.critter_id }},
+            xref_collection_unit: { connect: { collection_unit_id: c.collection_unit_id }}
+          }
+        })
+      }
     }
     for (let i = 0; i < locations.length; i++) {
       const l = locations[i];
@@ -148,7 +161,13 @@ const bulkUpdateData = async (bulkParams: IBulkMutate) => {
     for (let i = 0; i < _deleteMarkings.length; i++) {
       const _dma = _deleteMarkings[i];
       counts.deleted.markings = i + 1;
+      console.log('Will delete marking ' + _dma.marking_id);
       await deleteMarking(_dma.marking_id);
+    }
+    for(let i = 0; i < _deleteUnits.length; i++) {
+      const _dma = _deleteUnits[i];
+      counts.deleted.collections = i + 1;
+      await deleteCollectionUnit(_dma.critter_collection_unit_id);
     }
   }, {timeout: 90000});
   return counts;

--- a/src/api/critter/critter.service.ts
+++ b/src/api/critter/critter.service.ts
@@ -274,7 +274,6 @@ const getSimilarCritters = async (
         location: formatLocationNameSearch(m.location),
       },
     });
-    console.log(JSON.stringify(mortality_result))
     mortality.push(...mortality_result);
   }
 

--- a/src/api/marking/marking.router.ts
+++ b/src/api/marking/marking.router.ts
@@ -11,10 +11,12 @@ import {
   getMarkingById,
   getMarkingsByCritterId,
   updateMarking,
+  verifyMarkingsAgainstTaxon,
 } from "./marking.service";
 import {
   MarkingCreateBodySchema,
   MarkingUpdateBodySchema,
+  MarkingVerificationSchema,
   markingResponseSchema,
 } from "./marking.utils";
 
@@ -45,6 +47,14 @@ markingRouter.post(
     return res.status(201).json(newMarking);
   })
 );
+
+markingRouter.post("/verify",
+  catchErrors(async (req: Request, res: Response) => {
+    const parsed = MarkingVerificationSchema.parse(req.body);
+    const problems = await verifyMarkingsAgainstTaxon(parsed.taxon_id, parsed.markings);
+    return res.status(200).json(problems);
+  }
+));
 
 markingRouter.route("/critter/:id").get(
   catchErrors(async (req: Request, res: Response) => {

--- a/src/api/marking/marking.service.ts
+++ b/src/api/marking/marking.service.ts
@@ -1,3 +1,4 @@
+import { marking } from "@prisma/client";
 import { prisma } from "../../utils/constants";
 import { ReqBody } from "../../utils/types";
 import { getBodyLocationByNameAndTaxonUUID, getColourByName } from "../lookup/lookup.service";
@@ -7,6 +8,7 @@ import {
   MarkingUpdateInput,
   markingIncludes,
 } from "./marking.utils";
+import { db_getTaxonIds } from "../../utils/helper_functions";
 
 /**
  * * Returns all existing markings from the database
@@ -124,6 +126,32 @@ const appendEnglishMarkingsAsUUID = async (
   return body;
 };
 
+const verifyMarkingsAgainstTaxon = async (
+  taxon_id: string,
+  body: (Partial<marking> & Pick<marking, 'marking_id' | 'taxon_marking_body_location_id'>)[]
+): Promise<string[]> => {
+  const hier = await db_getTaxonIds(taxon_id);
+  const marking_ids: string[] = body.map(a => a.marking_id);
+  const markings = await prisma.marking.findMany({
+    include: {
+      xref_taxon_marking_body_location: {
+        select: {
+          taxon_id: true
+        }
+      }
+    },
+    where: { marking_id: { in: marking_ids }}
+  });
+  const problemIds = [];
+  for (const m of markings) {
+    const curr_id = m.xref_taxon_marking_body_location.taxon_id;
+    if(!hier.includes(curr_id) && taxon_id != curr_id ) {
+      problemIds.push(m.marking_id)
+    }
+  }
+  return problemIds;
+}
+
 export {
   getAllMarkings,
   getMarkingById,
@@ -131,5 +159,6 @@ export {
   updateMarking,
   createMarking,
   deleteMarking,
-  appendEnglishMarkingsAsUUID
+  appendEnglishMarkingsAsUUID,
+  verifyMarkingsAgainstTaxon
 };

--- a/src/api/marking/marking.utils.ts
+++ b/src/api/marking/marking.utils.ts
@@ -171,6 +171,11 @@ const MarkingDeleteSchema = markingSchema
   .pick({ marking_id: true })
   .extend(DeleteSchema.shape);
 
+const MarkingVerificationSchema = z.object({
+  taxon_id: zodID,
+  markings: z.array(markingSchema.partial().required({marking_id: true, taxon_marking_body_location_id: true}))
+});
+
 export {
   MarkingCreateBodySchema,
   MarkingUpdateBodySchema,
@@ -180,6 +185,7 @@ export {
   MarkingCreateWithEnglishSchema,
   MarkingDeleteSchema,
   MarkingUpdateByIdSchema,
+  MarkingVerificationSchema
 };
 export type {
   MarkingCreateInput,

--- a/src/api/measurement/measurement.router.ts
+++ b/src/api/measurement/measurement.router.ts
@@ -12,8 +12,11 @@ import {
   getQuantMeasurementOrThrow,
   updateQualMeasurement,
   updateQuantMeasurement,
+  verifyQualitativeMeasurementsAgainstTaxon,
+  verifyQuantitativeMeasurementsAgainstTaxon,
 } from "./measurement.service";
 import {
+  MeasurementVerificationSchema,
   QualitativeCreateSchema,
   QualitativeResponseSchema,
   QualitativeUpdateSchema,
@@ -56,6 +59,19 @@ measurementRouter.post(
     return res.status(201).json(measurement);
   })
 );
+
+measurementRouter.post(
+  '/verify',
+  catchErrors(async (req: Request, res: Response) => {
+    const parsed = MeasurementVerificationSchema.parse(req.body);
+    const qual = await verifyQualitativeMeasurementsAgainstTaxon(parsed.taxon_id, parsed.qualitative);
+    const quan = await verifyQuantitativeMeasurementsAgainstTaxon(parsed.taxon_id, parsed.quantitative);
+    return res.status(200).json({
+      qualitative: qual,
+      quantitative: quan
+    });
+  })
+)
 
 /**
  ** Create new quantitative measurement

--- a/src/api/measurement/measurement.service.ts
+++ b/src/api/measurement/measurement.service.ts
@@ -12,6 +12,7 @@ import {
   QuantitativeBody,
   QuantitativeUpdateBody,
 } from "./measurement.utils";
+import { db_getTaxonIds } from "../../utils/helper_functions";
 
 const getAllQuantMeasurements = async (): Promise<
   measurement_quantitative[]
@@ -131,6 +132,58 @@ const deleteQuantMeasurement = async (
   });
 };
 
+const verifyQuantitativeMeasurementsAgainstTaxon = async (
+  taxon_id: string,
+  body: Partial<measurement_quantitative> & Pick<measurement_quantitative, 'measurement_quantitative_id' | 'taxon_measurement_id'>[]
+): Promise<string[]> => {
+  const hier = await db_getTaxonIds(taxon_id);
+  const measurement_ids: string[] = body.map(m => m.measurement_quantitative_id);
+  const measurements = await prisma.measurement_quantitative.findMany({
+    include: {
+      xref_taxon_measurement_quantitative: {
+        select: {
+          taxon_id: true
+        }
+      }
+    },
+    where: { measurement_quantitative_id: { in: measurement_ids } }
+  });
+  const problemIds = [];
+  for (const m of measurements) { 
+    const curr_id = m.xref_taxon_measurement_quantitative.taxon_id;
+    if(!hier.includes(curr_id) && taxon_id != curr_id) {
+      problemIds.push(m.measurement_quantitative_id);
+    }
+  }
+  return problemIds;
+}
+
+const verifyQualitativeMeasurementsAgainstTaxon = async (
+  taxon_id: string,
+  body: Partial<measurement_qualitative> & Pick<measurement_qualitative, 'measurement_qualitative_id' | 'taxon_measurement_id'>[]
+): Promise<string[]> => {
+  const hier = await db_getTaxonIds(taxon_id);
+  const measurement_ids: string[] = body.map(m => m.measurement_qualitative_id);
+  const measurements = await prisma.measurement_qualitative.findMany({
+    include: {
+      xref_taxon_measurement_qualitative: {
+        select: {
+          taxon_id: true
+        }
+      }
+    },
+    where: { measurement_qualitative_id: { in: measurement_ids } }
+  });
+  const problemIds = [];
+  for (const m of measurements) { 
+    const curr_id = m.xref_taxon_measurement_qualitative.taxon_id;
+    if(!hier.includes(curr_id) && taxon_id != curr_id) {
+      problemIds.push(m.measurement_qualitative_id);
+    }
+  }
+  return problemIds;
+}
+
 export {
   getAllQualMeasurements,
   getQualMeasurementOrThrow,
@@ -145,4 +198,6 @@ export {
   getMeasurementsByCritterId,
   updateQuantMeasurement,
   updateQualMeasurement,
+  verifyQualitativeMeasurementsAgainstTaxon,
+  verifyQuantitativeMeasurementsAgainstTaxon
 };

--- a/src/api/measurement/measurement.utils.ts
+++ b/src/api/measurement/measurement.utils.ts
@@ -128,6 +128,14 @@ const QuantitativeUpdateSchema = QuantitativeCreateSchema.partial().refine(
   "body must include at least one property"
 );
 
+const QuantitativeVerificationSchema = QuantitativeSchema.partial().required({measurement_quantitative_id: true, taxon_measurement_id: true});
+const QualitatitiveVerificationSchema = QualitativeSchema.partial().required({measurement_qualitative_id: true, taxon_measurement_id: true})
+const MeasurementVerificationSchema = z.object({
+  taxon_id: zodID,
+  quantitative: z.array(QuantitativeVerificationSchema),
+  qualitative: z.array(QualitatitiveVerificationSchema)
+})
+
 const QuantitativeResponseSchema = ResponseSchema.transform((val) => {
   const { xref_taxon_measurement_quantitative: x, ...rest } =
     val as Prisma.PromiseReturnType<typeof getQuantMeasurementOrThrow>;
@@ -162,4 +170,7 @@ export {
   QuantitativeCreateSchema,
   QualitativeUpdateSchema,
   QuantitativeUpdateSchema,
+  QuantitativeVerificationSchema,
+  QualitatitiveVerificationSchema,
+  MeasurementVerificationSchema
 };

--- a/src/api/xref/xref.service.ts
+++ b/src/api/xref/xref.service.ts
@@ -1,4 +1,3 @@
-import console from "console";
 import { prisma } from "../../utils/constants";
 
 const getCollectionUnitsFromCategoryId = async (category_id: string) => {
@@ -7,7 +6,6 @@ const getCollectionUnitsFromCategoryId = async (category_id: string) => {
       collection_category_id: category_id,
     },
   });
-  console.log(collectionUnits);
   return collectionUnits;
 };
 
@@ -60,7 +58,6 @@ const getTaxonMarkingBodyLocations = async (taxon_id?: string) => {
   const result = await prisma.xref_taxon_marking_body_location.findMany(
     ids?.length ? { where: { taxon_id: { in: ids } } } : undefined
   );
-  console.log(result);
   return result;
 };
 

--- a/src/utils/helper_functions.ts
+++ b/src/utils/helper_functions.ts
@@ -4,6 +4,7 @@ import type { Request } from "express";
 import { ZodRawShape, ZodTypeAny, array, objectOutputType } from "zod";
 import { FormatParse, ISelect, QueryFormats } from "./types";
 import { QueryFormatSchema } from "./zod_helpers";
+import { prisma } from "./constants";
 /**
  ** Formats a prisma error messsage based on the prisma error code
  * @param code string
@@ -82,6 +83,17 @@ const toSelect = <AsType>(
     value: String(castVal[valueKey]),
   } satisfies ISelect;
 };
+
+const db_getTaxonIds = async (taxon_id: string): Promise<string[]> => {
+  const result: {get_taxon_ids: string[]}[] = await prisma.$queryRaw`SELECT * FROM get_taxon_ids(${taxon_id})`;
+  if(!result.length) {
+    return [];
+  }
+  else {
+    return result[0].get_taxon_ids;
+  }
+}
+
 export {
   prismaErrorMsg,
   sessionHours,
@@ -89,4 +101,5 @@ export {
   getFormat,
   intersect,
   toSelect,
+  db_getTaxonIds
 };

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -119,6 +119,18 @@ type ReqBody<T> = Record<string, unknown> & Partial<T>;
 
 type PrismaTransactionClient = Omit<PrismaClient<Prisma.PrismaClientOptions, never, Prisma.RejectOnNotFound | Prisma.RejectPerOperation | undefined>, "$connect" | "$disconnect" | "$on" | "$transaction" | "$use">;
 
+type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never };
+
+/**
+ * XOR is needed to have a real mutually exclusive union type
+ * https://stackoverflow.com/questions/42123407/does-typescript-support-mutually-exclusive-types
+ */
+type XOR<T, U> =
+  T extends object ?
+  U extends object ?
+    (Without<T, U> & U) | (Without<U, T> & T)
+  : U : T
+
 export {
   apiError,
   AuditColumns,
@@ -128,5 +140,6 @@ export {
   ISelect,
   FormatParseBody,
   ReqBody,
-  PrismaTransactionClient
+  PrismaTransactionClient,
+  XOR
 };


### PR DESCRIPTION
This PR updates the functionality in the bulk update endpoint so that it can delete collection units on the inclusion of a _delete: true entry. The basic case was also expanded to allow creation of collection units in the case of a missing primary key. This is done because the Edit Critter page may sometimes do all three of creation, update, and delete at once for this table. 