### PR TITLE
Migration from AWS SDK V2 to AWS SDK V3

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,13 +38,14 @@
     "typescript": "^4.9.5"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.370.0",
+    "@aws-sdk/s3-request-presigner": "^3.370.0",
     "@prisma/client": "^4.11.0",
     "@types/cookie-parser": "^1.4.3",
     "@types/cors": "^2.8.13",
     "@types/express": "^4.17.17",
     "@types/express-session": "^1.17.7",
     "@types/nodemon": "^1.19.2",
-    "aws-sdk": "^2.729.0",
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",

--- a/src/api/artifact/artifact.service.ts
+++ b/src/api/artifact/artifact.service.ts
@@ -6,8 +6,11 @@ import {
   ArtifactUpdate,
 } from "./artifact.utils";
 import { randomUUID } from "crypto";
-import { getFileDownloadUrl, uploadFileToS3 } from "../../utils/object_store";
-import { S3 } from "aws-sdk";
+import {
+  Metadata,
+  getFileDownloadUrl,
+  uploadFileToS3,
+} from "../../utils/object_store";
 
 /**
  * * Gets an artifact by the artifact_id
@@ -78,8 +81,7 @@ const createArtifact = async (
   artifact_data: ArtifactCreate,
   file: Express.Multer.File
 ): Promise<ArtifactResponse> => {
-  // TODO: user and timestamp metadata could be added here, but this is redundant with the database
-  const metadata: S3.Metadata = {
+  const metadata: Metadata = {
     filename: file.originalname,
   };
   const artifact_id = randomUUID();
@@ -107,8 +109,10 @@ const deleteArtifact = async (artifact_id: string): Promise<artifact> => {
  * * Adds a signed URL to an artifact
  * @param {artifact} artifact
  */
-const addSignedUrlToArtifact = (artifact: artifact): ArtifactResponse => {
-  const signed_url = getFileDownloadUrl(artifact.artifact_url);
+const addSignedUrlToArtifact = async (
+  artifact: artifact
+): Promise<ArtifactResponse> => {
+  const signed_url = await getFileDownloadUrl(artifact.artifact_url);
   return { ...artifact, signed_url };
 };
 
@@ -116,8 +120,10 @@ const addSignedUrlToArtifact = (artifact: artifact): ArtifactResponse => {
  * * Maps over an array of artifacts and adds a signed URL to each one
  * @param {artifact[]} artifacts
  */
-const addSignedUrlToArtifacts = (artifacts: artifact[]): ArtifactResponse[] =>
-  artifacts.map(addSignedUrlToArtifact);
+const addSignedUrlToArtifacts = async (
+  artifacts: artifact[]
+): Promise<ArtifactResponse[]> =>
+  Promise.all(artifacts.map(addSignedUrlToArtifact));
 
 export {
   getArtifactById,


### PR DESCRIPTION
This PR updates the usage of AWS SDK from deprecated V2 to V3, bringing modularity, native async/await support, and customizable middleware.

Key changes:

- AWS SDK service client instantiation code is updated.
- S3 file upload and download functions are refactored to use new command-based methods.
- Associated tests are updated to mock V3 clients and commands.
- Confirmed application functionality with new SDK.