### PR TITLE
267 taxon filter not applying

### DIFF
--- a/src/api/critter/critter.router.ts
+++ b/src/api/critter/critter.router.ts
@@ -43,6 +43,7 @@ export const CritterRouter = (db: ICbDatabase) => {
             taxon_name_common: {
               [taxon_name_commons.negate ? "notIn" : "in"]:
                 taxon_name_commons.body,
+              mode: 'insensitive'
             },
           },
         });

--- a/src/api/xref/xref.router.ts
+++ b/src/api/xref/xref.router.ts
@@ -3,7 +3,7 @@ import { prisma } from "../../utils/constants";
 import { ICbDatabase } from "../../utils/database";
 import { formatParse, getFormat } from "../../utils/helper_functions";
 import { catchErrors } from "../../utils/middleware";
-import { taxonIdSchema, taxonMeasurementIdSchema, uuidParamsSchema } from "../../utils/zod_helpers";
+import { taxonIdSchema, taxonMeasurementIdSchema } from "../../utils/zod_helpers";
 import {
   CollectionUnitCategoryIdSchema,
   CollectionUnitCategorySchema,
@@ -12,7 +12,6 @@ import {
   xrefTaxonMarkingBodyLocationFormats,
   xrefTaxonMeasurementOptionSchema,
   xrefTaxonMeasurementSchema,
-  xrefTaxonQuantitativeMeasurementFormats,
 } from "./xref.utils";
 
 export const XrefRouter = (db: ICbDatabase) => {

--- a/src/api/xref/xref.utils.ts
+++ b/src/api/xref/xref.utils.ts
@@ -5,7 +5,6 @@ import {
   xref_collection_unit,
   xref_taxon_marking_body_location,
   xref_taxon_measurement_qualitative,
-  xref_taxon_measurement_quantitative,
   xref_taxon_measurement_qualitative_option,
 } from "@prisma/client";
 import { z } from "zod";


### PR DESCRIPTION
Changes the taxon common name match in the filtering endpoint to be case insensitive. BCTW was sending these taxon names spelt correctly but in lower case, and the result was obtaining telemetry for more than just the requested taxon.