### PR TITLE
SIMSBIOHUB-239: Keycloak Service Token Auth

### DIFF
--- a/src/api/xref/xref.router.ts
+++ b/src/api/xref/xref.router.ts
@@ -3,7 +3,10 @@ import { prisma } from "../../utils/constants";
 import { ICbDatabase } from "../../utils/database";
 import { formatParse, getFormat } from "../../utils/helper_functions";
 import { catchErrors } from "../../utils/middleware";
-import { taxonIdSchema, taxonMeasurementIdSchema, uuidParamsSchema } from "../../utils/zod_helpers";
+import {
+  taxonIdSchema,
+  taxonMeasurementIdSchema,
+} from "../../utils/zod_helpers";
 import {
   CollectionUnitCategoryIdSchema,
   CollectionUnitCategorySchema,
@@ -12,7 +15,6 @@ import {
   xrefTaxonMarkingBodyLocationFormats,
   xrefTaxonMeasurementOptionSchema,
   xrefTaxonMeasurementSchema,
-  xrefTaxonQuantitativeMeasurementFormats,
 } from "./xref.utils";
 
 export const XrefRouter = (db: ICbDatabase) => {
@@ -100,10 +102,14 @@ export const XrefRouter = (db: ICbDatabase) => {
   xrefRouter.get(
     "/taxon-qualitative-measurement-options",
     catchErrors(async (req: Request, res: Response) => {
-      const { taxon_measurement_id } = taxonMeasurementIdSchema.parse(req.query);
+      const { taxon_measurement_id } = taxonMeasurementIdSchema.parse(
+        req.query
+      );
       const response = await formatParse(
         getFormat(req),
-        prisma.xref_taxon_measurement_qualitative_option.findMany({ where: { taxon_measurement_id } }),
+        prisma.xref_taxon_measurement_qualitative_option.findMany({
+          where: { taxon_measurement_id },
+        }),
         xrefTaxonMeasurementOptionSchema
       );
       res.status(200).json(response);

--- a/src/api/xref/xref.utils.ts
+++ b/src/api/xref/xref.utils.ts
@@ -5,7 +5,6 @@ import {
   xref_collection_unit,
   xref_taxon_marking_body_location,
   xref_taxon_measurement_qualitative,
-  xref_taxon_measurement_quantitative,
   xref_taxon_measurement_qualitative_option,
 } from "@prisma/client";
 import { z } from "zod";
@@ -17,7 +16,7 @@ import { getTaxonCollectionCategories } from "./xref.service";
 const CollectionUnitCategorySchema = implement<
   Partial<
     Pick<lk_taxon, "taxon_name_common" | "taxon_name_latin"> &
-    Pick<lk_collection_category, "category_name">
+      Pick<lk_collection_category, "category_name">
   >
 >().with({
   category_name: z.string(),
@@ -65,9 +64,14 @@ const xrefTaxonMeasurementSchema: FormatParse = {
 const xrefTaxonMeasurementOptionSchema: FormatParse = {
   asSelect: {
     schema: ResponseSchema.transform((val) =>
-      toSelect<xref_taxon_measurement_qualitative_option>(val, "qualitative_option_id", "option_label"))
-  }
-}
+      toSelect<xref_taxon_measurement_qualitative_option>(
+        val,
+        "qualitative_option_id",
+        "option_label"
+      )
+    ),
+  },
+};
 
 const xrefTaxonMarkingBodyLocationFormats: FormatParse = {
   asSelect: {
@@ -95,5 +99,5 @@ export {
   xrefTaxonCollectionCategoryFormats,
   xrefTaxonMarkingBodyLocationFormats,
   xrefTaxonMeasurementSchema,
-  xrefTaxonMeasurementOptionSchema
+  xrefTaxonMeasurementOptionSchema,
 };

--- a/src/authentication/auth.ts
+++ b/src/authentication/auth.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
 import { Request } from "express";
 import { apiError } from "../utils/types";
-import { JwtPayload, decode, verify } from 'jsonwebtoken';
-import { JwksClient } from 'jwks-rsa';
+import { JwtPayload, decode, verify } from "jsonwebtoken";
+import { JwksClient } from "jwks-rsa";
 
 const KEYCLOAK_URL = `${process.env.KEYCLOAK_HOST}/realms/${process.env.KEYCLOAK_REALM}/protocol/openid-connect/certs`;
 const KEYCLOAK_ISSUER = `${process.env.KEYCLOAK_HOST}/realms/${process.env.KEYCLOAK_REALM}`;
@@ -13,9 +13,9 @@ type BCGovJwtPayload = JwtPayload & {
   bceid_business_guid?: string;
   idir_username?: string;
   bceid_username?: string;
-}
+};
 
-type UserHeader = {
+interface IUserHeader {
   keycloak_guid: string;
   username: string;
 }
@@ -29,43 +29,45 @@ type UserHeader = {
  * @return {*} {Promise<true>} true if the token is authenticated
  * @throws {HTTP401} if the bearer token is missing or invalid
  */
-export const authenticateRequest = async function(req: Request): Promise<{ keycloak_uuid: string, system_name: string, identifier: string }> {
+export const authenticateRequest = async function (
+  req: Request
+): Promise<{ keycloak_uuid: string; system_name: string; identifier: string }> {
   try {
     if (!req.headers.authorization) {
-      console.log('No auth header found');
-      throw apiError.forbidden('Access Denied');
+      console.log("No auth header found");
+      throw apiError.forbidden("Access Denied");
     }
     // Authorization header should be a string with format: Bearer xxxxxx.yyyyyyy.zzzzzz
     const authorizationHeaderString = req.headers.authorization;
 
     // Check if the header is a valid bearer format
-    if (!authorizationHeaderString.startsWith('Bearer ')) {
-      console.log('Could not get Bearer format.')
-      throw apiError.forbidden('Access Denied');
+    if (!authorizationHeaderString.startsWith("Bearer ")) {
+      console.log("Could not get Bearer format.");
+      throw apiError.forbidden("Access Denied");
     }
 
     // Parse out token portion of the authorization header
-    const tokenString = authorizationHeaderString.split(' ')[1];
+    const tokenString = authorizationHeaderString.split(" ")[1];
 
     if (!tokenString) {
-      console.log('Could not get tokenString');
-      throw apiError.forbidden('Access Denied');
+      console.log("Could not get tokenString");
+      throw apiError.forbidden("Access Denied");
     }
 
     // Decode token without verifying signature
     const decodedToken = decode(tokenString, { complete: true, json: true });
 
     if (!decodedToken) {
-      console.log('Could not decode token.');
-      throw apiError.forbidden('Access Denied');
+      console.log("Could not decode token.");
+      throw apiError.forbidden("Access Denied");
     }
 
     // Get token header kid (key id)
     const kid = decodedToken.header.kid;
 
     if (!kid) {
-      console.log('No key id in token');
-      throw apiError.forbidden('Access Denied');
+      console.log("No key id in token");
+      throw apiError.forbidden("Access Denied");
     }
 
     const jwksClient = new JwksClient({ jwksUri: KEYCLOAK_URL });
@@ -76,32 +78,37 @@ export const authenticateRequest = async function(req: Request): Promise<{ keycl
     // This ESLint warning makes no sense
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (!key) {
-      console.log('Key not found.');
-      throw apiError.forbidden('Access Denied');
+      console.log("Key not found.");
+      throw apiError.forbidden("Access Denied");
     }
 
     // Parse out public portion of signing key
     const signingKey = key.getPublicKey();
 
     // Verify token using public signing key
-    const verifiedToken = verify(tokenString, signingKey, { issuer: [KEYCLOAK_ISSUER] });
+    const verifiedToken = verify(tokenString, signingKey, {
+      issuer: [KEYCLOAK_ISSUER],
+    });
 
-    if (!verifiedToken || typeof verifiedToken === 'string') {
-      console.log('Could not verify token.');
-      throw apiError.forbidden('Access Denied');
+    if (!verifiedToken || typeof verifiedToken === "string") {
+      console.log("Could not verify token.");
+      throw apiError.forbidden("Access Denied");
     }
 
-    const allowedAudiences = String(process.env.ALLOWED_AUD).split(' ');
+    const allowedAudiences = String(process.env.ALLOWED_AUD).split(" ");
     const bcgovToken = verifiedToken as BCGovJwtPayload;
 
-    if (typeof bcgovToken.aud !== 'string' || !allowedAudiences.includes(bcgovToken.aud)) {
-      console.log('Client not found');
-      throw apiError.forbidden('Access Denied');
+    if (
+      typeof bcgovToken.aud !== "string" ||
+      !allowedAudiences.includes(bcgovToken.aud)
+    ) {
+      console.log("Client not found");
+      throw apiError.forbidden("Access Denied");
     }
 
-    const user = JSON.parse(req.headers.user as string) as UserHeader;
+    const user = JSON.parse(req.headers.user as string) as IUserHeader;
     if (!user.keycloak_guid || !user.username) {
-      throw apiError.syntaxIssue('User header was not provided.');
+      throw apiError.syntaxIssue("User header was not provided.");
     }
 
     console.log(JSON.stringify(bcgovToken, null, 2));
@@ -113,7 +120,6 @@ export const authenticateRequest = async function(req: Request): Promise<{ keycl
     };
   } catch (error) {
     console.log(JSON.stringify(error));
-    throw apiError.forbidden('Access Denied');
+    throw apiError.forbidden("Access Denied");
   }
 };
-

--- a/src/authentication/auth.ts
+++ b/src/authentication/auth.ts
@@ -93,6 +93,7 @@ export const authenticateRequest = async function(req: Request): Promise<{ keycl
 
     const allowedAudiences = String(process.env.ALLOWED_AUD).split(' ');
     const bcgovToken = verifiedToken as BCGovJwtPayload;
+
     if (typeof bcgovToken.aud !== 'string' || !allowedAudiences.includes(bcgovToken.aud)) {
       console.log('Client not found');
       throw apiError.forbidden('Access Denied');
@@ -102,10 +103,13 @@ export const authenticateRequest = async function(req: Request): Promise<{ keycl
     if (!user.keycloak_guid || !user.username) {
       throw apiError.syntaxIssue('User header was not provided.');
     }
+
+    console.log(JSON.stringify(bcgovToken, null, 2));
+
     return {
-      keycloak_uuid: user.keycloak_guid,
+      keycloak_uuid: user.keycloak_guid.toUpperCase(),
       identifier: user.username,
-      system_name: String(bcgovToken.client_id),
+      system_name: String(bcgovToken.clientId),
     };
   } catch (error) {
     console.log(JSON.stringify(error));


### PR DESCRIPTION
This PR changes the way that requests are authorized with Keycloak. Requests must contain a keycloak token from the BCTW or SIMS service accounts (this can be expanded if needed by other services). For auditing purposes, the username and keycloak_guid of the user making the call must be sent with the request in the 'user' header.