### PR TITLE
SIMSBIOHUB206 - Small fix to allow detailed response on filtering critters

### DIFF
--- a/src/api/critter/critter.router.ts
+++ b/src/api/critter/critter.router.ts
@@ -74,9 +74,12 @@ export const CritterRouter = (db: ICbDatabase) => {
             }
           : undefined,
       };
+      if(Object.values(whereInput).every(a => !a)) {
+        return res.status(200).json([]);
+      }
       const allCritters = await formatParse(
         getFormat(req),
-        db.getAllCritters(QueryFormats.default, whereInput),
+        db.getAllCritters(getFormat(req), whereInput),
         critterFormats
       );
       return res.status(200).json(allCritters);

--- a/src/api/critter/critter.router.ts
+++ b/src/api/critter/critter.router.ts
@@ -4,7 +4,7 @@ import express, { NextFunction, Request, Response } from "express";
 import { prisma } from "../../utils/constants";
 import { formatParse, getFormat } from "../../utils/helper_functions";
 import { catchErrors } from "../../utils/middleware";
-import { QueryFormats, apiError } from "../../utils/types";
+import { apiError } from "../../utils/types";
 import { uuidParamsSchema } from "../../utils/zod_helpers";
 
 import {


### PR DESCRIPTION
Filter endpoint would only send default critter format regardless of what was in the query, now passing detailed will work correctly.