### PR TITLE
Bulk Delete Client Fix

### DIFF
--- a/src/api/bulk/bulk.service.ts
+++ b/src/api/bulk/bulk.service.ts
@@ -249,42 +249,42 @@ const bulkDeleteData = async (bulkParams: IBulkDelete, db: ICbDatabase) => {
     for (let i = 0; i < _deleteMarkings.length; i++) {
       const _dma = _deleteMarkings[i];
       counts.deleted.markings = i + 1;
-      await db.deleteMarking(_dma.marking_id);
+      await db.deleteMarking(_dma.marking_id, prisma);
     }
     for (let i = 0; i < _deleteUnits.length; i++) {
       const _dma = _deleteUnits[i];
       counts.deleted.collections = i + 1;
-      await db.deleteCollectionUnit(_dma.critter_collection_unit_id);
+      await db.deleteCollectionUnit(_dma.critter_collection_unit_id, prisma);
     }
     for (let i = 0; i < _deleteCaptures.length; i++) {
       const _dma = _deleteCaptures[i];
       counts.deleted.captures = i + 1;
-      await db.deleteCapture(_dma.capture_id);
+      await db.deleteCapture(_dma.capture_id, prisma);
     }
     for (let i = 0; i < _deleteMoralities.length; i++) {
       const _dma = _deleteMoralities[i];
       counts.deleted.mortalities = i + 1;
-      await db.deleteMortality(_dma.mortality_id);
+      await db.deleteMortality(_dma.mortality_id, prisma);
     }
     for (let i = 0; i < _deleteQual.length; i++) {
       const _dma = _deleteQual[i];
       counts.deleted.qualitative_measurements = i + 1;
-      await db.deleteQualMeasurement(_dma.measurement_qualitative_id);
+      await db.deleteQualMeasurement(_dma.measurement_qualitative_id, prisma);
     }
     for (let i = 0; i < _deleteQuant.length; i++) {
       const _dma = _deleteQuant[i];
       counts.deleted.captures = i + 1;
-      await db.deleteQuantMeasurement(_dma.measurement_quantitative_id);
+      await db.deleteQuantMeasurement(_dma.measurement_quantitative_id, prisma);
     }
     for (let i = 0; i < _deleteParents.length; i++) {
       const _dma = _deleteParents[i];
       counts.deleted.family_parents = i + 1;
-      await db.removeParentOfFamily(_dma.family_id, _dma.parent_critter_id);
+      await db.removeParentOfFamily(_dma.family_id, _dma.parent_critter_id, prisma);
     }
     for(let i = 0; i < _deleteChildren.length; i++) {
       const _dma = _deleteChildren[i];
       counts.deleted.family_children = i + 1;
-      await db.removeChildOfFamily(_dma.family_id, _dma.child_critter_id);
+      await db.removeChildOfFamily(_dma.family_id, _dma.child_critter_id, prisma);
     }
   });
   return counts;

--- a/src/api/capture/capture.service.ts
+++ b/src/api/capture/capture.service.ts
@@ -110,24 +110,25 @@ const updateCapture = async (
   });
 };
 
-const deleteCapture = async (capture_id: string): Promise<capture | null> => {
-  const capture = await prisma.capture.findUniqueOrThrow({
+const deleteCapture = async (capture_id: string, prismaOverride?: PrismaTransactionClient): Promise<capture | null> => {
+  const client = prismaOverride ?? prisma;
+  const capture = await client.capture.findUniqueOrThrow({
     where: {
       capture_id: capture_id
     }
   });
-  const captureRes = await prisma.capture.delete({
+  const captureRes = await client.capture.delete({
     where: {
       capture_id: capture_id,
     },
   });
   if(capture.capture_location_id) {
-    await prisma.location.delete({
+    await client.location.delete({
       where: {location_id: capture.capture_location_id}
     })
   }
   if(capture.release_location_id) {
-    await prisma.location.delete({
+    await client.location.delete({
       where: {location_id: capture.release_location_id}
     })
   }

--- a/src/api/collectionUnit/collectionUnit.service.ts
+++ b/src/api/collectionUnit/collectionUnit.service.ts
@@ -1,4 +1,5 @@
 import { prisma } from "../../utils/constants";
+import { PrismaTransactionClient } from "../../utils/types";
 import {
   CollectionUnitCreateInput,
   collectionUnitIncludes,
@@ -89,9 +90,11 @@ const createCollectionUnit = async (
  * @param {string} critter_collection_unit_id
  */
 const deleteCollectionUnit = async (
-  critter_collection_unit_id: string
+  critter_collection_unit_id: string,
+  prismaOverride?: PrismaTransactionClient
 ): Promise<CollectionUnitIncludes> => {
-  const collectionUnit = await prisma.critter_collection_unit.delete({
+  const client = prismaOverride ?? prisma;
+  const collectionUnit = await client.critter_collection_unit.delete({
     where: {
       critter_collection_unit_id: critter_collection_unit_id,
     },

--- a/src/api/family/family.service.ts
+++ b/src/api/family/family.service.ts
@@ -9,6 +9,7 @@ import {
   FamilyUpdate,
   ImmediateFamily,
 } from "./family.utils";
+import { PrismaTransactionClient } from "../../utils/types";
 
 const getAllFamilies = async (): Promise<family[]> => {
   return await prisma.family.findMany();
@@ -167,9 +168,11 @@ const makeParentOfFamily = async (
 
 const removeChildOfFamily = async (
   family_id: string,
-  child_critter_id: string
+  child_critter_id: string,
+  prismaOverride?: PrismaTransactionClient
 ): Promise<family_child> => {
-  const result = await prisma.family_child.delete({
+  const client = prismaOverride ?? prisma;
+  const result = await client.family_child.delete({
     where: {
       family_id_child_critter_id: {
         family_id: family_id,
@@ -182,9 +185,11 @@ const removeChildOfFamily = async (
 
 const removeParentOfFamily = async (
   family_id: string,
-  parent_critter_id: string
+  parent_critter_id: string,
+  prismaOverride?: PrismaTransactionClient
 ): Promise<family_parent> => {
-  const result = await prisma.family_parent.delete({
+  const client = prismaOverride ?? prisma;
+  const result = await client.family_parent.delete({
     where: {
       family_id_parent_critter_id: {
         family_id: family_id,

--- a/src/api/marking/marking.service.ts
+++ b/src/api/marking/marking.service.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, marking } from "@prisma/client";
+import { marking } from "@prisma/client";
 import { prisma } from "../../utils/constants";
 import { PrismaTransactionClient, ReqBody } from "../../utils/types";
 import {

--- a/src/api/marking/marking.service.ts
+++ b/src/api/marking/marking.service.ts
@@ -1,6 +1,6 @@
-import { marking } from "@prisma/client";
+import { PrismaClient, marking } from "@prisma/client";
 import { prisma } from "../../utils/constants";
-import { ReqBody } from "../../utils/types";
+import { PrismaTransactionClient, ReqBody } from "../../utils/types";
 import {
   getBodyLocationByNameAndTaxonUUID,
   getColourByName,
@@ -91,8 +91,9 @@ const createMarking = async (newMarkingData: MarkingCreateInput) => {
  * * Removes a marking from the database
  * @param {string} marking_id
  */
-const deleteMarking = async (marking_id: string): Promise<MarkingIncludes> => {
-  const marking: MarkingIncludes = await prisma.marking.delete({
+const deleteMarking = async (marking_id: string, prismaOverride?: PrismaTransactionClient): Promise<MarkingIncludes> => {
+  const client = prismaOverride ?? prisma;
+  const marking: MarkingIncludes = await client.marking.delete({
     where: {
       marking_id: marking_id,
     },

--- a/src/api/measurement/measurement.service.ts
+++ b/src/api/measurement/measurement.service.ts
@@ -13,6 +13,7 @@ import {
   QuantitativeUpdateBody,
 } from "./measurement.utils";
 import { getParentTaxonIds } from "../../utils/helper_functions";
+import { PrismaTransactionClient } from "../../utils/types";
 
 const getAllQuantMeasurements = async (): Promise<
   measurement_quantitative[]
@@ -113,9 +114,11 @@ const updateQuantMeasurement = async (
 };
 
 const deleteQualMeasurement = async (
-  id: string
+  id: string,
+  prismaOverride?: PrismaTransactionClient
 ): Promise<measurement_qualitative> => {
-  return await prisma.measurement_qualitative.delete({
+  const client = prismaOverride ?? prisma;
+  return await client.measurement_qualitative.delete({
     where: {
       measurement_qualitative_id: id,
     },
@@ -123,9 +126,11 @@ const deleteQualMeasurement = async (
 };
 
 const deleteQuantMeasurement = async (
-  id: string
+  id: string,
+  prismaOverride?: PrismaTransactionClient
 ): Promise<measurement_quantitative> => {
-  return await prisma.measurement_quantitative.delete({
+  const client = prismaOverride ?? prisma;
+  return await client.measurement_quantitative.delete({
     where: {
       measurement_quantitative_id: id,
     },

--- a/src/api/mortality/mortality.service.ts
+++ b/src/api/mortality/mortality.service.ts
@@ -127,19 +127,20 @@ const updateMortality = async (
   });
 };
 
-const deleteMortality = async (mortality_id: string) => {
-  const mortality = await prisma.mortality.findUniqueOrThrow({
+const deleteMortality = async (mortality_id: string, prismaOverride?: PrismaTransactionClient) => {
+  const client = prismaOverride ?? prisma;
+  const mortality = await client.mortality.findUniqueOrThrow({
     where: {
       mortality_id: mortality_id
     }
   });
-  const mortalityRes = await prisma.mortality.delete({
+  const mortalityRes = await client.mortality.delete({
     where: {
       mortality_id: mortality_id,
     },
   });
   if(mortality.location_id) {
-    await prisma.location.delete({
+    await client.location.delete({
       where: {
         location_id: mortality.location_id
       }


### PR DESCRIPTION
Modifies delete services to accept a prisma client override. Now these services can be passed the transaction instance of the client. Using the default client inside transactioncs can lead to unexpected behavior.