### PR TITLE
Capture Release Same Location Delete Bug

### DIFF
--- a/src/api/capture/capture.service.ts
+++ b/src/api/capture/capture.service.ts
@@ -127,7 +127,7 @@ const deleteCapture = async (capture_id: string, prismaOverride?: PrismaTransact
       where: {location_id: capture.capture_location_id}
     })
   }
-  if(capture.release_location_id) {
+  if(capture.release_location_id && capture.capture_location_id !== capture.release_location_id) { //If using same location the row is already deleted by the above call.
     await client.location.delete({
       where: {location_id: capture.release_location_id}
     })


### PR DESCRIPTION
Small bug fix to prevent attempt at deleting same row twice when capture and release point to same location id