### PR TITLE
Add endpoint for capture and mortality geometry & include captures in multiple critters request

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ run-postgres: ## Runs the postgres db containers
 	@echo "==============================================="
 	@echo "Make: run-postgres - running postgres db images"
 	@echo "==============================================="
-	@docker-compose -f docker-compose.yml up -d critterbase-db crtterbase-db_setup
+	@docker-compose -f docker-compose.yml up -d critterbase-db critterbase-db_setup
 
 
 ## ------------------------------------------------------------------------------

--- a/src/api/critter/critter.router.test.ts
+++ b/src/api/critter/critter.router.test.ts
@@ -6,6 +6,7 @@ const id = '3277ea2a-38ee-4aa4-a9af-b2c40d8cb940';
 const mockCritterService = {
   getAllCritters: jest.fn(),
   getMultipleCrittersByIds: jest.fn(),
+  getMultipleCrittersGeometryByIds: jest.fn(),
   getCritterById: jest.fn(),
   getAllCrittersOrCrittersWithWlhId: jest.fn(),
   updateCritter: jest.fn(),
@@ -88,6 +89,18 @@ describe('Critter Router', () => {
         const res = await request.post(`/api/critters/unique`).send(payload);
 
         expect(mockCritterService.findSimilarCritters.mock.calls[0][0]).toStrictEqual(payload);
+        expect(res.status).toBe(200);
+        expect(res.body).toBe(true);
+      });
+    });
+
+    describe('POST critter/spatial - get capture and mortality geometry for multiple critters', () => {
+      it('should respond with status 200 and return response', async () => {
+        mockCritterService.getMultipleCrittersGeometryByIds.mockResolvedValueOnce(true);
+        const payload = { critter_ids: [id] };
+        const res = await request.post(`/api/critters/spatial`).send(payload);
+
+        expect(mockCritterService.getMultipleCrittersGeometryByIds.mock.calls[0][0]).toStrictEqual([id]);
         expect(res.status).toBe(200);
         expect(res.body).toBe(true);
       });

--- a/src/api/critter/critter.router.ts
+++ b/src/api/critter/critter.router.ts
@@ -54,6 +54,22 @@ export const CritterRouter = (db: ICbDatabase) => {
   );
 
   /**
+   * Fetch capture and mortality locations for multiple critters
+   * Note: Post Request.
+   *
+   */
+  critterRouter.post(
+    '/spatial',
+    catchErrors(async (req: Request, res: Response) => {
+      const { critter_ids } = CritterIdsRequestSchema.parse(req.body);
+
+      const response = await db.critterService.getMultipleCrittersGeometryByIds(critter_ids);
+
+      return res.status(200).json(response);
+    })
+  );
+
+  /**
    * Find critters by semi-unique attributes.
    *
    */

--- a/src/api/critter/critter.swagger.ts
+++ b/src/api/critter/critter.swagger.ts
@@ -116,8 +116,7 @@ export const critterPaths = {
             'application/json': {
               schema: {
                 oneOf: [
-                  { $ref: '#/components/schemas/defaultCritterResponseArray' },
-                  { $ref: '#/components/schemas/detailedManyCritterResponseArray' }
+                  { $ref: '#/components/schemas/defaultCritterGeometryResponse' }
                 ]
               }
             }

--- a/src/api/critter/critter.swagger.ts
+++ b/src/api/critter/critter.swagger.ts
@@ -115,9 +115,7 @@ export const critterPaths = {
           content: {
             'application/json': {
               schema: {
-                oneOf: [
-                  { $ref: '#/components/schemas/defaultCritterGeometryResponse' }
-                ]
+                oneOf: [{ $ref: '#/components/schemas/defaultCritterGeometryResponse' }]
               }
             }
           }

--- a/src/api/critter/critter.swagger.ts
+++ b/src/api/critter/critter.swagger.ts
@@ -8,6 +8,7 @@ import {
   DetailedManyCritterSchema,
   SimilarCritterQuerySchema
 } from '../../schemas/critter-schema';
+import { CaptureMortalityGeometrySchema } from '../../schemas/spatial-schema';
 import { routes } from '../../utils/constants';
 import { SwagDesc, SwagErr, SwagNotFound, SwagUnauthorized } from '../../utils/swagger_helpers';
 import { QueryFormats } from '../../utils/types';
@@ -19,7 +20,8 @@ export const critterSchemas = {
   defaultCritterResponse: CritterSchema,
   detailedCritterResponse: DetailedCritterSchema,
   defaultCritterResponseArray: z.array(CritterSchema),
-  detailedManyCritterResponseArray: z.array(DetailedManyCritterSchema)
+  detailedManyCritterResponseArray: z.array(DetailedManyCritterSchema),
+  defaultCritterGeometryResponse: CaptureMortalityGeometrySchema
 };
 
 export const critterPaths = {
@@ -64,6 +66,42 @@ export const critterPaths = {
       requestParams: {
         query: z.object({ format: z.enum([QueryFormats.detailed]).optional() })
       },
+      requestBody: {
+        content: {
+          'application/json': {
+            schema: CritterIdsRequestSchema
+          }
+        }
+      },
+      responses: {
+        '200': {
+          description: SwagDesc.get,
+          content: {
+            'application/json': {
+              schema: {
+                oneOf: [
+                  { $ref: '#/components/schemas/defaultCritterResponseArray' },
+                  { $ref: '#/components/schemas/detailedManyCritterResponseArray' }
+                ]
+              }
+            }
+          }
+        },
+        ...SwagErr,
+        ...SwagUnauthorized,
+        ...SwagNotFound
+      }
+    }
+  },
+  [`${routes.critters}/spatial`]: {
+    /**
+     * Get capture and mortality geometry for multiple critter IDs
+     *
+     */
+    post: {
+      operationId: 'crittersGeometryByIds',
+      summary: 'Retrieve capture and mortality geometry for specific critters by their critter ids.',
+      tags: [TAG],
       requestBody: {
         content: {
           'application/json': {

--- a/src/repositories/critter-repository.test.ts
+++ b/src/repositories/critter-repository.test.ts
@@ -176,6 +176,43 @@ describe('xref-repository', () => {
     });
   });
 
+  describe('getMultipleCrittersGeometryByIds', () => {
+    beforeEach(() => {
+      mockPrismaClient = {
+        $queryRaw: jest.fn()
+      };
+    });
+
+    it('should return capture and mortality geometries successfully', async () => {
+      const mockCaptureResult = [
+        {
+          capture_id: 'capture1',
+          coordinates: [12.35, -134.33]
+        },
+        {
+          capture_id: 'capture2',
+          coordinates: [14.39, -119.48]
+        }
+      ];
+
+      const mockMortalityResult = [
+        {
+          mortality_id: 'mortality1',
+          coordinates: [14.39, -119.48]
+        }
+      ];
+
+      const mockResponse = { captures: mockCaptureResult, mortalities: mockMortalityResult };
+
+      mockPrismaClient.$queryRaw.mockResolvedValue([mockResponse]);
+
+      const critterRepository = new CritterRepository(mockPrismaClient);
+      const result = await critterRepository.getMultipleCrittersGeometryByIds(['critter1', 'critter2']);
+
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
   describe('getCritterById', () => {
     beforeEach(() => {
       mockPrismaClient = {

--- a/src/repositories/critter-repository.ts
+++ b/src/repositories/critter-repository.ts
@@ -19,6 +19,7 @@ import {
   IDetailedManyCritter,
   SimilarCritterQuery
 } from '../schemas/critter-schema';
+import { CaptureMortalityGeometry, CaptureMortalityGeometrySchema } from '../schemas/spatial-schema';
 import { apiError } from '../utils/types';
 import { Repository } from './base-repository';
 
@@ -96,6 +97,10 @@ export class CritterRepository extends Repository {
    * Additional properties include:
    *    mortality: mortality_id + mortality_timestamp.
    *    collection_units: relevant collection_unit related properties.
+   *    captures, including:
+   *      - markings
+   *      - quantitative measurements
+   *      - qualitative measurements
    *
    * @async
    * @param {string[]} critter_ids - array of critter ids.
@@ -105,47 +110,201 @@ export class CritterRepository extends Repository {
   async getMultipleCrittersByIdsDetailed(critter_ids: string[]): Promise<IDetailedManyCritter[]> {
     const result = await this.safeQuery(
       Prisma.sql`
+      WITH 
+    -- Mortality CTE
+    mortality AS (
         SELECT
-          c.critter_id,
-          c.itis_tsn,
-          c.itis_scientific_name,
-          c.wlh_id,
-          c.animal_id,
-          c.sex,
-          c.responsible_region_nr_id,
-          c.critter_comment,
-          COALESCE(
+            m.critter_id,
             json_agg(json_build_object(
-              'mortality_id', m.mortality_id,
-              'mortality_timestamp', m.mortality_timestamp
-            )) FILTER(WHERE m.mortality_id IS NOT NULL),
-            '[]'
-          ) as mortality,
-          COALESCE(
+                'mortality_id', m.mortality_id,
+                'mortality_timestamp', m.mortality_timestamp
+            )) AS mortality
+        FROM mortality m
+        WHERE m.critter_id = ANY(${critter_ids}::uuid[])
+        GROUP BY m.critter_id
+    ),
+
+    -- Collection units CTE
+    collection_units AS (
+        SELECT
+            u.critter_id,
             json_agg(json_build_object(
-              'critter_collection_unit_id', u.critter_collection_unit_id,
-              'collection_category_id', l.collection_category_id,
-              'collection_unit_id', x.collection_unit_id,
-              'unit_name', x.unit_name,
-              'category_name', l.category_name
-            )) FILTER(WHERE u.critter_collection_unit_id IS NOT NULL),
-            '[]'
-          ) as collection_units
+                'critter_collection_unit_id', u.critter_collection_unit_id,
+                'collection_category_id', l.collection_category_id,
+                'collection_unit_id', x.collection_unit_id,
+                'unit_name', x.unit_name,
+                'category_name', l.category_name
+            )) AS collection_units
+        FROM critter_collection_unit u
+        JOIN xref_collection_unit x ON u.collection_unit_id = x.collection_unit_id
+        JOIN lk_collection_category l ON x.collection_category_id = l.collection_category_id
+        WHERE u.critter_id = ANY(${critter_ids}::uuid[])
+        GROUP BY u.critter_id
+    ),
+
+    -- Captures CTE
+    captures AS (
+        SELECT
+            c.critter_id,
+            COALESCE(json_agg(json_build_object(
+                'capture_id', ca.capture_id,
+                'capture_comment', ca.capture_comment,
+                'release_comment', ca.release_comment,
+                'capture_location', json_build_object(
+                    'location_id', capture_loc.location_id,
+                    'latitude', capture_loc.latitude,
+                    'longitude', capture_loc.longitude,
+                    'coordinate_uncertainty', capture_loc.coordinate_uncertainty,
+                    'coordinate_uncertainty_unit', capture_loc.coordinate_uncertainty_unit,
+                    'location_comment', capture_loc.location_comment
+                ),
+                'release_location', json_build_object(
+                    'location_id', release_loc.location_id,
+                    'latitude', release_loc.latitude,
+                    'longitude', release_loc.longitude,
+                    'coordinate_uncertainty', release_loc.coordinate_uncertainty,
+                    'coordinate_uncertainty_unit', release_loc.coordinate_uncertainty_unit,
+                    'location_comment', release_loc.location_comment
+                ),
+                'markings', COALESCE(markings.markings, '[]'::json),
+                'quantitative_measurements', COALESCE(quan.quantitative_measurements, '[]'::json),
+                'qualitative_measurements', COALESCE(qual.qualitative_measurements, '[]'::json)
+            )), '[]'::json) AS captures
         FROM critter c
-        LEFT JOIN mortality m
-          ON c.critter_id = m.critter_id
-        LEFT JOIN critter_collection_unit u
-          ON c.critter_id = u.critter_id
-        LEFT JOIN xref_collection_unit x
-          ON x.collection_unit_id = u.collection_unit_id
-        LEFT JOIN lk_collection_category l
-          ON l.collection_category_id = x.collection_category_id
+        LEFT JOIN capture ca ON c.critter_id = ca.critter_id
+        LEFT JOIN location capture_loc ON capture_loc.location_id = ca.capture_location_id
+        LEFT JOIN location release_loc ON release_loc.location_id = ca.release_location_id
+        LEFT JOIN (
+            SELECT
+                m.capture_id,
+                json_agg(json_build_object(
+                    'marking_id', m.marking_id,
+                    'identifier', m.identifier,
+                    'frequency', m.frequency,
+                    'frequency_unit', m.frequency_unit,
+                    'comment', m.comment,
+                    'taxon_marking_body_location', tmbl.body_location,
+                    'marking_type', mt.name,
+                    'primary_colour', lc_primary.colour,
+                    'secondary_colour', lc_secondary.colour
+                )) AS markings
+            FROM marking m
+            LEFT JOIN xref_taxon_marking_body_location tmbl ON tmbl.taxon_marking_body_location_id = m.taxon_marking_body_location_id
+            LEFT JOIN lk_marking_type mt ON mt.marking_type_id = m.marking_type_id
+            LEFT JOIN lk_colour lc_primary ON lc_primary.colour_id = m.primary_colour_id
+            LEFT JOIN lk_colour lc_secondary ON lc_secondary.colour_id = m.secondary_colour_id
+            GROUP BY m.capture_id
+        ) AS markings ON markings.capture_id = ca.capture_id
+        LEFT JOIN (
+            SELECT
+                mq.capture_id,
+                json_agg(json_build_object(
+                    'measurement_quantitative_id', mq.measurement_quantitative_id,
+                    'measurement_name', xtmq.measurement_name,
+                    'value', mq.value,
+                    'comment', mq.measurement_comment
+                )) AS quantitative_measurements
+            FROM measurement_quantitative mq
+            LEFT JOIN xref_taxon_measurement_quantitative xtmq ON xtmq.taxon_measurement_id = mq.taxon_measurement_id
+            GROUP BY mq.capture_id
+        ) AS quan ON quan.capture_id = ca.capture_id
+        LEFT JOIN (
+            SELECT
+                mq.capture_id,
+                json_agg(json_build_object(
+                    'measurement_qualitative_id', mq.measurement_qualitative_id,
+                    'measurement_name', xtmq.measurement_name,
+                    'value', xtmqo.option_label,
+                    'comment', mq.measurement_comment
+                )) AS qualitative_measurements
+            FROM measurement_qualitative mq
+            LEFT JOIN xref_taxon_measurement_qualitative xtmq ON xtmq.taxon_measurement_id = mq.taxon_measurement_id
+            LEFT JOIN xref_taxon_measurement_qualitative_option xtmqo ON xtmqo.qualitative_option_id = mq.qualitative_option_id
+            GROUP BY mq.capture_id
+        ) AS qual ON qual.capture_id = ca.capture_id
         WHERE c.critter_id = ANY(${critter_ids}::uuid[])
-        GROUP BY c.critter_id;`,
+        GROUP BY c.critter_id
+    )
+
+    -- Main query combining all CTEs
+    SELECT
+        c.critter_id,
+        c.itis_tsn,
+        c.itis_scientific_name,
+        c.wlh_id,
+        c.animal_id,
+        c.sex,
+        c.responsible_region_nr_id,
+        c.critter_comment,
+        COALESCE(m.mortality, '[]'::json) AS mortality,
+        COALESCE(cu.collection_units, '[]'::json) AS collection_units,
+        COALESCE(ca.captures, '[]'::json) AS captures
+    FROM 
+        critter c
+    LEFT JOIN 
+        mortality m ON c.critter_id = m.critter_id
+    LEFT JOIN 
+        collection_units cu ON c.critter_id = cu.critter_id
+    LEFT JOIN 
+        captures ca ON c.critter_id = ca.critter_id
+    WHERE 
+        c.critter_id = ANY(${critter_ids}::uuid[]);
+    `,
       z.array(DetailedManyCritterSchema)
     );
 
     return result;
+  }
+
+  /**
+   * Get capture and mortality geometry for multiple critters
+   *
+   * @async
+   * @param {string[]} critter_ids
+   * @returns {Promise<ICaptureMortalityGeometrySchema>}
+   *
+   */
+  async getMultipleCrittersGeometryByIds(critter_ids: string[]): Promise<CaptureMortalityGeometry> {
+    const result = await this.safeQuery(
+      Prisma.sql`
+          WITH 
+          captures AS (
+              SELECT
+                  json_build_object(
+                      'capture_id', ca.capture_id,
+                      'coordinates', ARRAY[cl.latitude, cl.longitude]::NUMERIC[]
+                  ) AS geometry
+              FROM capture ca
+              JOIN location cl ON ca.capture_location_id = cl.location_id
+              WHERE ca.critter_id = ANY(${critter_ids}::uuid[])
+          ),
+          mortalities AS (
+              SELECT
+                  json_build_object(
+                      'mortality_id', m.mortality_id,
+                      'coordinates', ARRAY[ml.latitude, ml.longitude]::NUMERIC[]
+                  ) AS geometry
+              FROM mortality m
+              JOIN location ml ON m.location_id = ml.location_id
+              WHERE m.critter_id = ANY(${critter_ids}::uuid[])
+          )
+          SELECT
+              COALESCE(json_agg(captures.geometry), '[]'::json) AS captures,
+              COALESCE(json_agg(mortalities.geometry), '[]'::json) AS mortalities
+          FROM
+              captures, mortalities;
+          `,
+      z.array(CaptureMortalityGeometrySchema)
+    );
+
+    if (!result[0]) {
+      throw apiError.notFound(`Failed to find critter geometry.`, [
+        'CritterRepository -> getMultipleCrittersGeometryById',
+        'result was undefined'
+      ]);
+    }
+
+    return result[0];
   }
 
   /**

--- a/src/schemas/location-schema.ts
+++ b/src/schemas/location-schema.ts
@@ -30,14 +30,6 @@ export const LocationSchema = implement<Location>()
   .openapi({ description: 'Responds with default location' });
 
 /**
- * Schema for a GeoJSON Point
- */
-export const PointSchema = z.object({
-  type: z.literal('Point'),
-  coordinates: z.array(z.number())
-});
-
-/**
  * Create location schema
  *
  */

--- a/src/schemas/location-schema.ts
+++ b/src/schemas/location-schema.ts
@@ -30,6 +30,14 @@ export const LocationSchema = implement<Location>()
   .openapi({ description: 'Responds with default location' });
 
 /**
+ * Schema for a GeoJSON Point
+ */
+export const PointSchema = z.object({
+  type: z.literal('Point'),
+  coordinates: z.array(z.number())
+});
+
+/**
  * Create location schema
  *
  */

--- a/src/schemas/spatial-schema.ts
+++ b/src/schemas/spatial-schema.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const CaptureMortalityGeometrySchema = z.object({
+  captures: z.array(z.object({ capture_id: z.string(), coordinates: z.array(z.number(), z.number()) })),
+  mortalities: z.array(z.object({ mortality_id: z.string(), coordinates: z.array(z.number(), z.number()) }))
+});
+
+export type CaptureMortalityGeometry = z.infer<typeof CaptureMortalityGeometrySchema>;

--- a/src/services/critter-service.ts
+++ b/src/services/critter-service.ts
@@ -7,6 +7,7 @@ import {
   IDetailedManyCritter,
   SimilarCritterQuery
 } from '../schemas/critter-schema';
+import { CaptureMortalityGeometry } from '../schemas/spatial-schema';
 import { defaultFormat } from '../utils/constants';
 import { QueryFormats } from '../utils/types';
 import { Service } from './base-service';
@@ -94,6 +95,17 @@ export class CritterService implements Service {
       return this.repository.getMultipleCrittersByIdsDetailed(critterIds);
     }
     return this.repository.getMultipleCrittersByIds(critterIds);
+  }
+
+  /**
+   * Get capture and mortality geometry for multiple critter IDs
+   *
+   * @async
+   * @param {string[]} critterIds - array of critter ids.
+   * @returns {Promise<ICritter[] | IDetailedManyCritter[]>} default or detailed critter objects.
+   */
+  async getMultipleCrittersGeometryByIds(critterIds: string[]): Promise<CaptureMortalityGeometry> {
+    return this.repository.getMultipleCrittersGeometryByIds(critterIds);
   }
 
   /**


### PR DESCRIPTION
- Added `api/critters/spatial`, which returns the geometry for all capture and mortality events for the critters specified.
- Included captures in the response of `api/critters/?format=detailed`
- Added tests for code changes