### PR TITLE
TSN Hierarchy Fix

### DIFF
--- a/src/services/itis-service.test.ts
+++ b/src/services/itis-service.test.ts
@@ -102,12 +102,6 @@ describe('ItisService', () => {
         expect(data).toBeDefined();
         expect(data.length).toBe(2);
       });
-
-      it('should throw error if no hierarchy returned', async () => {
-        expect(async () => {
-          await service.getTsnHierarchy(focalTsn);
-        }).rejects.toThrow('ITIS TSN produced invalid hierarchy.');
-      });
     });
 
     describe('getScientificNameFromTsn', () => {

--- a/src/services/itis-service.ts
+++ b/src/services/itis-service.ts
@@ -134,10 +134,6 @@ export class ItisService extends ExternalService {
   async getTsnHierarchy(searchTsn: number) {
     const { tsnHierarchy } = await this.searchSolrByTsn(searchTsn);
 
-    if (tsnHierarchy[tsnHierarchy.length - 1] !== searchTsn) {
-      throw apiError.requestIssue(`ITIS TSN produced invalid hierarchy.`, ['ItisWebService -> getTsnHierarchy']);
-    }
-
     return tsnHierarchy;
   }
 


### PR DESCRIPTION
{
  method: 'GET',
  url: '/api/xref/taxon-collection-categories?tsn=898198',
  error: apiError: ITIS TSN produced invalid hierarchy.
      at Function.requestIssue (/opt/app-root/src/src/utils/types.ts:57:12)
      at ItisService.getTsnHierarchy (/opt/app-root/src/src/services/itis-service.ts:138:22)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
      at XrefService.getTsnCollectionCategories (/opt/app-root/src/src/services/xref-service.ts:124:18)
      at /opt/app-root/src/src/api/xref/xref.router.ts:93:24 {
    status: 400,
    errorType: 'requestIssue',
    errors: [ 'ItisWebService -> getTsnHierarchy' ]
  }
}

If a TSN becomes invalid, the hierarchy string uses the TSN that superseded it, instead of the old tsn

## Description of Changes

- Removes the validation check that the last TSN in the hierarchy == the searched TSN, since this isn't reliable for outdated TSNs.